### PR TITLE
Updated campaign validation per the latest code from:

### DIFF
--- a/src/GoogleAnalytics/Campaign.php
+++ b/src/GoogleAnalytics/Campaign.php
@@ -251,13 +251,11 @@ class Campaign {
 	}
 	
 	/**
-	 * @link http://code.google.com/p/gaforflash/source/browse/trunk/src/com/google/analytics/campaign/CampaignTracker.as#153
+	 * @link http://code.google.com/p/gaforflash/source/browse/trunk/src/com/google/analytics/campaign/CampaignTracker.as#166
 	 */
 	public function validate() {
-		// NOTE: gaforflash states that id and gClickId must also be specified,
-		// but that doesn't seem to be correct
-		if(!$this->source) {
-			Tracker::_raiseError('Campaigns need to have at least the "source" attribute defined.', __METHOD__);
+		if(!($this->source || $this->id || $this->gClickId)) {
+			Tracker::_raiseError('Campaigns need to have at least the one of the following attributes defined: "source", "id", "gClickId".', __METHOD__);
 		}
 	}
 	


### PR DESCRIPTION
In the code from gaforflash for campaign validation, they are checking if at least one of the attributes "source", "id", "gClickId" is set: 
https://code.google.com/p/gaforflash/source/browse/trunk/src/com/google/analytics/campaign/CampaignTracker.as#166.
The php-ga library is only verifying that the source attribute is set.

I have the situation where the visitor comes with a gClickId and nothing else, witch fails validation because no source is present. But after changing the validation code, and letting this through, it is recorded correctly by GA, and shows up correctly in the GA admin.

I assume that GA changed the algorithm at some point, so this code is basically updating the validation to the current status quo.
