### PR TITLE
Added link to php-ga-measurement-protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,7 @@ where it has 8,000+ downloads and 160+ stares.
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 **NOTE:** php-ga is no longer maintained as Google finally released an official server-side
 tracking API: [Measurement Protocol](https://developers.google.com/analytics/devguides/collection/protocol/v1/)!
-I couldn't find any well-implemented client library for PHP yet, so feel free to help make
-php-ga 2.0 a Measurement Protocol PHP client library.
+If you're looking for a well-implemented client library for PHP take a look at [php-ga-measurement-protocol](https://github.com/krizon/php-ga-measurement-protocol).
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 You might also be interested in the companion project [php-gacx](https://github.com/thomasbachem/php-gacx)


### PR DESCRIPTION
Hi @thomasbachem,

I hope you would consider placing this link to the php-ga-measurement-protocol library. I'm guessing your project still gets a lot of traffic since it was the only proper way of doing serverside tracking with GA and I think this link can help people navigate to a proper PHP library for the Measurement Protocol API. 

I'll add a thank you and link in the readme of php-ga-measurement-protocol.

Thank you
