### PR TITLE
Fix Undefined property: page

### DIFF
--- a/src/GoogleAnalytics/Internals/Request/EventRequest.php
+++ b/src/GoogleAnalytics/Internals/Request/EventRequest.php
@@ -42,6 +42,11 @@ class EventRequest extends Request {
 	
 	
 	/**
+	 * @var \UnitedPrototype\GoogleAnalytics\Page
+	 */
+	private $page;
+	
+	/**
 	 * @const int
 	 */
 	const X10_EVENT_PROJECT_ID = 5;


### PR DESCRIPTION
The private variable was not defined. 

This issue https://github.com/mustela/php-ga/commit/4a887f851bff9ad5255705162d36454530fc7d53, was actually because the variable $page didn't exists.
